### PR TITLE
fix(ui): don't strand the viewer under the video progress overlay

### DIFF
--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentImagePreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentImagePreview.tsx
@@ -19,7 +19,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import type { ImageDTO } from 'services/api/types';
 
-import { useImageViewerContext } from './context';
+import { SELECTED_ITEM_REVEAL_DURATION_MS, useImageViewerContext } from './context';
 import { NoContentForViewer } from './NoContentForViewer';
 import { ProgressImage } from './ProgressImage2';
 import { ProgressImageTiles } from './ProgressImageTiles';
@@ -38,6 +38,7 @@ export const CurrentImagePreview = memo(({ imageDTO }: { imageDTO: ImageDTO | nu
     $activeProgressData,
     $isProgressImageResolving,
     $isTemporarilyShowingSelectedImage,
+    lastRenderedItemNameRef,
   } = useImageViewerContext();
   const progressEvent = useStore($progressEvent);
   const progressImage = useStore($progressImage);
@@ -45,7 +46,6 @@ export const CurrentImagePreview = memo(({ imageDTO }: { imageDTO: ImageDTO | nu
   const isProgressImageResolving = useStore($isProgressImageResolving);
   const isTemporarilyShowingSelectedImage = useStore($isTemporarilyShowingSelectedImage);
   const [imageToRender, setImageToRender] = useState<ImageDTO | null>(null);
-  const previousRenderedImageNameRef = useRef<string | null>(null);
   const selectedImageRevealTimeoutId = useRef(0);
 
   useEffect(() => {
@@ -93,8 +93,16 @@ export const CurrentImagePreview = memo(({ imageDTO }: { imageDTO: ImageDTO | nu
 
   useEffect(() => {
     const renderedImageName = imageToRender?.image_name ?? null;
-    const previousRenderedImageName = previousRenderedImageNameRef.current;
-    previousRenderedImageNameRef.current = renderedImageName;
+    // The previous-item ref is shared with CurrentVideoPreview (via the viewer context) so a click
+    // that switches media type still reads as a selection change here. While a selection exists
+    // but its preload hasn't landed yet (renderedImageName still null on the mount run after a
+    // video -> image swap), the ref must NOT be overwritten — nulling it here would erase the
+    // "previous item was the video" fact and swallow the reveal this run's successor would fire.
+    // A genuinely empty selection does reset it, preserving the no-reveal-on-first-selection rule.
+    const previousRenderedItemName = lastRenderedItemNameRef.current;
+    if (renderedImageName !== null || !selectedImageName) {
+      lastRenderedItemNameRef.current = renderedImageName;
+    }
 
     window.clearTimeout(selectedImageRevealTimeoutId.current);
 
@@ -109,14 +117,14 @@ export const CurrentImagePreview = memo(({ imageDTO }: { imageDTO: ImageDTO | nu
       return;
     }
 
-    if (previousRenderedImageName === null || previousRenderedImageName === renderedImageName) {
+    if (previousRenderedItemName === null || previousRenderedItemName === renderedImageName) {
       return;
     }
 
     $isTemporarilyShowingSelectedImage.set(true);
     selectedImageRevealTimeoutId.current = window.setTimeout(() => {
       $isTemporarilyShowingSelectedImage.set(false);
-    }, SELECTED_IMAGE_REVEAL_DURATION_MS);
+    }, SELECTED_ITEM_REVEAL_DURATION_MS);
 
     return () => {
       window.clearTimeout(selectedImageRevealTimeoutId.current);
@@ -126,6 +134,7 @@ export const CurrentImagePreview = memo(({ imageDTO }: { imageDTO: ImageDTO | nu
     hasProgressImage,
     imageToRender?.image_name,
     isProgressImageResolving,
+    lastRenderedItemNameRef,
     selectedImageName,
     shouldShowProgressInViewer,
   ]);
@@ -271,5 +280,3 @@ const exit: AnimationProps['exit'] = {
   opacity: 0,
   transition: { duration: 0.07 },
 };
-
-const SELECTED_IMAGE_REVEAL_DURATION_MS = 2000;

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentVideoPreview.test.ts
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentVideoPreview.test.ts
@@ -11,3 +11,25 @@ describe('CurrentVideoPreview playback errors', () => {
     expect(source).toContain('onError={handleVideoError}');
   });
 });
+
+describe('CurrentVideoPreview progress overlay', () => {
+  const source = readFileSync(fileURLToPath(new URL('./CurrentVideoPreview.tsx', import.meta.url)), 'utf8');
+
+  it('lifts the overlay during the temporary reveal so mid-render thumbnail clicks visibly land', () => {
+    // The overlay must consult the shared reveal atom (and never re-cover an actively-playing
+    // video) — an unconditional overlay swallows every gallery click for the whole render.
+    expect(source).toMatch(
+      /withProgress =\s+shouldShowProgressInViewer && hasProgressImage && !isTemporarilyShowingSelectedImage && !isPlaying/
+    );
+    expect(source).toContain('SELECTED_ITEM_REVEAL_DURATION_MS');
+    // The previous-item ref must be the shared one from the viewer context, so image -> video
+    // clicks still read as a selection change after the preview component swaps.
+    expect(source).toContain('lastRenderedItemNameRef.current = videoName');
+  });
+
+  it('clears a pending post-render overlay when the video element errors', () => {
+    // onLoadedMetadata normally clears the resolve state; an errored element never fires it.
+    const errorHandler = source.slice(source.indexOf('const handleVideoError'), source.indexOf('const handlePlay'));
+    expect(errorHandler).toContain('onLoadImage()');
+  });
+});

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentVideoPreview.test.ts
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentVideoPreview.test.ts
@@ -27,6 +27,13 @@ describe('CurrentVideoPreview progress overlay', () => {
     expect(source).toContain('lastRenderedItemNameRef.current = videoName');
   });
 
+  it('tiles concurrent sessions instead of letting them overwrite each other (multi-GPU)', () => {
+    // CurrentImagePreview tiles per-session previews when several renders run at once; the video
+    // overlay must do the same or the sessions fight over the single full-size preview slot.
+    expect(source).toMatch(/withTiledProgress = withProgress && activeProgressData\.length > 1/);
+    expect(source).toContain('<ProgressImageTiles data={activeProgressData} />');
+  });
+
   it('clears a pending post-render overlay when the video element errors', () => {
     // onLoadedMetadata normally clears the resolve state; an errored element never fires it.
     const errorHandler = source.slice(source.indexOf('const handleVideoError'), source.indexOf('const handlePlay'));

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentVideoPreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentVideoPreview.tsx
@@ -30,7 +30,7 @@ import { useTranslation } from 'react-i18next';
 import { PiArrowSquareOutBold, PiCopyBold, PiDownloadSimpleBold, PiTrashSimpleBold, PiXBold } from 'react-icons/pi';
 import type { VideoDTO } from 'services/api/types';
 
-import { useImageViewerContext } from './context';
+import { SELECTED_ITEM_REVEAL_DURATION_MS, useImageViewerContext } from './context';
 import { NoContentForViewer } from './NoContentForViewer';
 import { ProgressImage } from './ProgressImage2';
 import { ProgressIndicator } from './ProgressIndicator2';
@@ -57,6 +57,8 @@ type Props = {
  * appear on top of the previously-loaded video. Without this, a freshly generated render's
  * progress images had nowhere to display whenever a video was the last-selected gallery
  * item (and the user only saw the static first-frame still until the new video finished).
+ * Also mirrors its temporary reveal: clicking a gallery thumbnail mid-render lifts the
+ * overlay briefly so the click visibly lands, then the live preview returns.
  */
 export const CurrentVideoPreview = memo(({ videoDTO }: Props) => {
   const videoUrl = useMediaUrl(videoDTO?.video_url);
@@ -71,16 +73,76 @@ export const CurrentVideoPreview = memo(({ videoDTO }: Props) => {
   const deleteVideoModal = useDeleteVideoModalApi();
   const { downloadItem } = useDownloadItem();
   const clipboard = useClipboard();
-  const { $progressEvent, $progressImage, onLoadImage } = useImageViewerContext();
+  const {
+    $progressEvent,
+    $progressImage,
+    $isProgressImageResolving,
+    $isTemporarilyShowingSelectedImage,
+    lastRenderedItemNameRef,
+    onLoadImage,
+  } = useImageViewerContext();
   const progressEvent = useStore($progressEvent);
   const progressImage = useStore($progressImage);
-  const withProgress = shouldShowProgressInViewer && progressImage !== null;
+  const isProgressImageResolving = useStore($isProgressImageResolving);
+  const isTemporarilyShowingSelectedImage = useStore($isTemporarilyShowingSelectedImage);
+  const hasProgressImage = progressImage !== null;
+  // `!isPlaying`: a reveal exposes the play button, and an explicit play is a stronger signal than
+  // the click that triggered the reveal — never re-cover an actively-playing video with the opaque
+  // overlay (its audio would keep running underneath, with the controls unreachable). The overlay
+  // returns when the user closes the player.
+  const withProgress =
+    shouldShowProgressInViewer && hasProgressImage && !isTemporarilyShowingSelectedImage && !isPlaying;
   const { goToPreviousImage, goToNextImage, isFetching } = useNextPrevItemNavigation();
+  const selectedVideoRevealTimeoutId = useRef(0);
 
   // Whenever the selected video changes, drop back to the idle still + play overlay.
   useEffect(() => {
     setIsPlaying(false);
   }, [videoName]);
+
+  // Mid-generation gallery clicks: mirror CurrentImagePreview's temporary reveal. Without this,
+  // the opaque progress overlay swallows every video-thumbnail click for the whole render — the
+  // selection changes underneath, but nothing visibly happens. Unlike the image path there is no
+  // preload step: the <video> renders immediately (first frame paints when metadata arrives), so
+  // the reveal is keyed directly off the selected video name. The previous-item ref is shared with
+  // CurrentImagePreview so an image -> video click still reads as a selection change.
+  useEffect(() => {
+    const previousRenderedItemName = lastRenderedItemNameRef.current;
+    lastRenderedItemNameRef.current = videoName;
+
+    window.clearTimeout(selectedVideoRevealTimeoutId.current);
+
+    if (!shouldShowProgressInViewer || !hasProgressImage || isProgressImageResolving || !videoName) {
+      $isTemporarilyShowingSelectedImage.set(false);
+      return;
+    }
+
+    if (previousRenderedItemName === null || previousRenderedItemName === videoName) {
+      return;
+    }
+
+    $isTemporarilyShowingSelectedImage.set(true);
+    selectedVideoRevealTimeoutId.current = window.setTimeout(() => {
+      $isTemporarilyShowingSelectedImage.set(false);
+    }, SELECTED_ITEM_REVEAL_DURATION_MS);
+
+    return () => {
+      window.clearTimeout(selectedVideoRevealTimeoutId.current);
+    };
+  }, [
+    $isTemporarilyShowingSelectedImage,
+    hasProgressImage,
+    isProgressImageResolving,
+    lastRenderedItemNameRef,
+    shouldShowProgressInViewer,
+    videoName,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      $isTemporarilyShowingSelectedImage.set(false);
+    };
+  }, [$isTemporarilyShowingSelectedImage]);
 
   // Register the viewer's <video> as a drag source so users can drag the currently-displayed
   // video onto node fields (e.g. a Video Primitive's "Starting Video" input) directly from
@@ -125,13 +187,17 @@ export const CurrentVideoPreview = memo(({ videoDTO }: Props) => {
     if (isMediaCookieSelfHealPending()) {
       return;
     }
+    // A genuinely errored element will never fire onLoadedMetadata, which is what normally clears
+    // a pending post-render progress overlay — clear it here or it strands over the viewer.
+    // (onLoadImage is a no-op unless a resolve is actually pending.)
+    onLoadImage();
     toast({
       id: 'VIDEO_PLAYBACK_FAILED',
       status: 'error',
       title: t('toast.videoPlaybackFailed'),
       description: t('toast.videoPlaybackFailedDesc'),
     });
-  }, [t]);
+  }, [onLoadImage, t]);
 
   const handlePlay = useCallback(() => {
     setIsPlaying(true);

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentVideoPreview.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/CurrentVideoPreview.tsx
@@ -33,6 +33,7 @@ import type { VideoDTO } from 'services/api/types';
 import { SELECTED_ITEM_REVEAL_DURATION_MS, useImageViewerContext } from './context';
 import { NoContentForViewer } from './NoContentForViewer';
 import { ProgressImage } from './ProgressImage2';
+import { ProgressImageTiles } from './ProgressImageTiles';
 import { ProgressIndicator } from './ProgressIndicator2';
 import { VideoPlayButtonOverlay } from './VideoPlayButtonOverlay';
 
@@ -76,6 +77,7 @@ export const CurrentVideoPreview = memo(({ videoDTO }: Props) => {
   const {
     $progressEvent,
     $progressImage,
+    $activeProgressData,
     $isProgressImageResolving,
     $isTemporarilyShowingSelectedImage,
     lastRenderedItemNameRef,
@@ -83,6 +85,7 @@ export const CurrentVideoPreview = memo(({ videoDTO }: Props) => {
   } = useImageViewerContext();
   const progressEvent = useStore($progressEvent);
   const progressImage = useStore($progressImage);
+  const activeProgressData = useStore($activeProgressData);
   const isProgressImageResolving = useStore($isProgressImageResolving);
   const isTemporarilyShowingSelectedImage = useStore($isTemporarilyShowingSelectedImage);
   const hasProgressImage = progressImage !== null;
@@ -92,6 +95,9 @@ export const CurrentVideoPreview = memo(({ videoDTO }: Props) => {
   // returns when the user closes the player.
   const withProgress =
     shouldShowProgressInViewer && hasProgressImage && !isTemporarilyShowingSelectedImage && !isPlaying;
+  // When more than one session is generating concurrently (multi-GPU), tile their previews instead
+  // of letting the sessions overwrite each other's full-size preview. Mirrors CurrentImagePreview.
+  const withTiledProgress = withProgress && activeProgressData.length > 1;
   const { goToPreviousImage, goToNextImage, isFetching } = useNextPrevItemNavigation();
   const selectedVideoRevealTimeoutId = useRef(0);
 
@@ -421,9 +427,15 @@ export const CurrentVideoPreview = memo(({ videoDTO }: Props) => {
       )}
       {withProgress && (
         <Flex w="full" h="full" position="absolute" alignItems="center" justifyContent="center" bg="base.900">
-          <ProgressImage progressImage={progressImage} />
-          {progressEvent && (
-            <ProgressIndicator progressEvent={progressEvent} position="absolute" top={6} right={6} size={8} />
+          {withTiledProgress ? (
+            <ProgressImageTiles data={activeProgressData} />
+          ) : (
+            <>
+              <ProgressImage progressImage={progressImage} />
+              {progressEvent && (
+                <ProgressIndicator progressEvent={progressEvent} position="absolute" top={6} right={6} size={8} />
+              )}
+            </>
           )}
         </Flex>
       )}

--- a/invokeai/frontend/web/src/features/gallery/components/ImageViewer/context.tsx
+++ b/invokeai/frontend/web/src/features/gallery/components/ImageViewer/context.tsx
@@ -5,7 +5,7 @@ import { selectAutoSwitch } from 'features/gallery/store/gallerySelectors';
 import type { ProgressImage as ProgressImageType } from 'features/nodes/types/common';
 import { LRUCache } from 'lru-cache';
 import { type Atom, atom, computed, map, type MapStore, type WritableAtom } from 'nanostores';
-import type { PropsWithChildren } from 'react';
+import type { MutableRefObject, PropsWithChildren } from 'react';
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { S } from 'services/api/types';
 import { getEventScope } from 'services/events/eventScope';
@@ -33,8 +33,22 @@ type ImageViewerContextValue = {
   $activeProgressData: Atom<ViewerProgressDatum[]>;
   $isProgressImageResolving: Atom<boolean>;
   $isTemporarilyShowingSelectedImage: WritableAtom<boolean>;
+  /** Name of the item most recently rendered by either preview component (image or video). Shared
+   * across the two components so a click that switches media type (image -> video or back) still
+   * reads as a selection change to the temporary-reveal logic — a per-component ref resets on the
+   * swap and would silently swallow the first reveal after every type switch. */
+  lastRenderedItemNameRef: MutableRefObject<string | null>;
   onLoadImage: () => void;
 };
+
+/** How long a mid-generation gallery click shows the clicked item before the live preview returns. */
+export const SELECTED_ITEM_REVEAL_DURATION_MS = 2000;
+
+/** Upper bound on the post-completion "progress preview resolves into the final media" illusion.
+ * The clear normally fires from the final image's onLoad / the final video's onLoadedMetadata, but
+ * on a slow connection that load can lag far behind completion — and if the media element errors,
+ * it never fires at all. Past this deadline we drop the illusion rather than strand the overlay. */
+const RESOLVE_FAILSAFE_MS = 10_000;
 
 const ImageViewerContext = createContext<ImageViewerContextValue | null>(null);
 
@@ -59,6 +73,8 @@ export const ImageViewerContextProvider = memo((props: PropsWithChildren) => {
   const $isProgressImageResolving = useState(() => atom(false))[0];
   const $isTemporarilyShowingSelectedImage = useState(() => atom(false))[0];
   const shouldClearProgressImageOnLoadRef = useRef(false);
+  const lastRenderedItemNameRef = useRef<string | null>(null);
+  const resolveFailsafeTimeoutRef = useRef(0);
   // We can have race conditions where we receive a progress event for a queue item that has already finished. Easiest
   // way to handle this is to keep track of finished queue items in a cache and ignore progress events for those.
   const [finishedQueueItemIds] = useState(() => new LRUCache<number, boolean>({ max: 200 }));
@@ -81,6 +97,8 @@ export const ImageViewerContextProvider = memo((props: PropsWithChildren) => {
         );
         return;
       }
+      // A new render owns the display now; a pending resolve (and its failsafe) is moot.
+      window.clearTimeout(resolveFailsafeTimeoutRef.current);
       shouldClearProgressImageOnLoadRef.current = false;
       $isProgressImageResolving.set(false);
       $progressEvent.set(data);
@@ -153,6 +171,7 @@ export const ImageViewerContextProvider = memo((props: PropsWithChildren) => {
           // will be stuck on the viewer.
           (data.origin === 'canvas' && data.destination !== 'canvas')
         ) {
+          window.clearTimeout(resolveFailsafeTimeoutRef.current);
           shouldClearProgressImageOnLoadRef.current = false;
           $isProgressImageResolving.set(false);
           $progressEvent.set(null);
@@ -160,6 +179,20 @@ export const ImageViewerContextProvider = memo((props: PropsWithChildren) => {
         } else {
           shouldClearProgressImageOnLoadRef.current = true;
           $isProgressImageResolving.set(true);
+          // Failsafe: onLoadImage normally performs this clear when the final media loads, but on
+          // a slow connection that can lag far behind completion, and an errored media element
+          // never fires it — stranding the opaque overlay until a tab switch remounts this
+          // provider. Past the deadline, drop the resolve illusion and clear directly.
+          window.clearTimeout(resolveFailsafeTimeoutRef.current);
+          resolveFailsafeTimeoutRef.current = window.setTimeout(() => {
+            if (!shouldClearProgressImageOnLoadRef.current) {
+              return;
+            }
+            shouldClearProgressImageOnLoadRef.current = false;
+            $isProgressImageResolving.set(false);
+            $progressEvent.set(null);
+            $progressImage.set(null);
+          }, RESOLVE_FAILSAFE_MS);
         }
       }
     };
@@ -185,11 +218,19 @@ export const ImageViewerContextProvider = memo((props: PropsWithChildren) => {
       return;
     }
 
+    window.clearTimeout(resolveFailsafeTimeoutRef.current);
     shouldClearProgressImageOnLoadRef.current = false;
     $isProgressImageResolving.set(false);
     $progressEvent.set(null);
     $progressImage.set(null);
   }, [$isProgressImageResolving, $progressEvent, $progressImage]);
+
+  useEffect(() => {
+    const timeoutRef = resolveFailsafeTimeoutRef;
+    return () => {
+      window.clearTimeout(timeoutRef.current);
+    };
+  }, []);
 
   const value = useMemo(
     () => ({
@@ -200,6 +241,7 @@ export const ImageViewerContextProvider = memo((props: PropsWithChildren) => {
       $activeProgressData,
       $isProgressImageResolving,
       $isTemporarilyShowingSelectedImage,
+      lastRenderedItemNameRef,
       onLoadImage,
     }),
     [


### PR DESCRIPTION
## Summary

**During a video render, the viewer was effectively locked.** The progress-preview overlay is opaque and sits on top of the selected media; gallery thumbnail clicks changed the selection underneath, but nothing visibly happened until a tab switch remounted the viewer (which resets the context's nanostore atoms — that's why the tab-switch "workaround" worked). Three causes, fixed together:

### 1. Videos never got the temporary reveal
`CurrentImagePreview` lifts the overlay for 2 s when the user clicks a thumbnail mid-render (#9217). `CurrentVideoPreview` showed the overlay unconditionally whenever a progress image existed — with a gallery full of videos, every click during a multi-minute render was silently swallowed. The reveal is now ported: the clicked video appears (first frame + play button) for 2 s, then the live preview returns. An actively-playing video is never re-covered — an explicit play is a stronger signal than the click that revealed it, and re-covering would leave audio running under an opaque overlay with unreachable controls. The overlay returns when the player is closed.

### 2. Media-type switches reset the reveal's memory
The reveal fires on a *change* of rendered item. That previous-item tracking was a per-component ref, but image↔video clicks swap the mounted preview component, so the ref reset and the first reveal after every type switch was swallowed. The ref now lives in the shared `ImageViewerContext`. The image side deliberately does not overwrite it while a selection's preload is still pending — the fresh-context adversarial review caught that the mount run (where `imageToRender` is still null) would otherwise erase the "previous item was a video" fact and kill the video→image reveal, which is half the point of sharing the ref.

### 3. The post-render "resolve" could strand the overlay
After completion (auto-switch on), the overlay is intentionally held until the final media loads, to create the progress-resolves-into-result illusion. That clear only fired from the final image's `onLoad` / final video's `onLoadedMetadata`. On a slow connection the load lags far behind completion, and an errored `<video>` (transient 401, network failure) never fires it — stranding the overlay permanently. Now: the video error handler clears a pending resolve (ref-gated, so it cannot blank a live mid-render preview), and a 10 s failsafe in the context drops the illusion rather than strand the overlay. The failsafe is defused by the load callback, by any new render's progress event, and by provider unmount; the review verified it cannot fire on top of a live preview.


### 4. Multi-GPU: concurrent sessions overwrote each other's video preview
`CurrentImagePreview` tiles per-session previews when more than one render runs concurrently (`ProgressImageTiles`); the video overlay only ever rendered the single shared latest preview, so parallel sessions overwrote each other's frames in place. The tiles branch is now ported, mirroring the image viewer exactly — `$activeProgressData` was already tracked per-session in the shared context.

## Adversarial review

A fresh-context review attacked the atom lifecycle (unmount-order interleavings on component swaps, cross-component stale timers, stuck-ON reveal), the shared ref (preload lag, rapid A→B→A clicks, deselect paths), the failsafe (multi-GPU completion sequences, coexisting timers, firing over a live preview), and the error-handler clear. One HIGH finding (the mount-run ref overwrite in item 2) and one LOW (play button exposure during reveal, item 1's `!isPlaying` guard) — both fixed. Remaining known race: the auto-switch reveal race the image path already has (fixed upstream-side by the identity-based mechanism on `fix/viewer-progress-image-handoff`; can be ported to videos when that merges — the two changes compose).

## Testing

`pnpm lint:tsc`, eslint, prettier clean; `CurrentVideoPreview.test.ts` extended with assertions pinning the overlay's reveal/playing guards, the shared-ref wiring, and the error-path clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
